### PR TITLE
set 0 seconds and milliseconds when parsing date

### DIFF
--- a/src/sb_light/utils/dates.js
+++ b/src/sb_light/utils/dates.js
@@ -82,7 +82,9 @@ define(['sb_light/globals','sb_light/utils/ext','sb_light/api/queries', 'moment'
 			if (format == D.serverFormat || date == "today") {
 				m.set({
 					hour: 12, 
-					minute: 0
+					minute: 0,
+					second: 0,
+					millisecond: 0
 				});
 			}
 			return m;


### PR DESCRIPTION
@glenn-strategyblocks merge request

Parsing "today" didn't set seconds and milliseconds to 0 which causes off-by-one when doing a date comparison.